### PR TITLE
Fixing Github actions using pre-commig

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,5 +15,6 @@ jobs:
         with:
           python-version: "3.10"
       - run: $CONDA/bin/conda env create -f env.yml
+      - run: $CONDA/bin/conda run -n lasse-py pip install -r requirements.txt
       - run: $CONDA/bin/conda run -n lasse-py pre-commit install
       - run: $CONDA/bin/conda run -n lasse-py pre-commit run --all-files


### PR DESCRIPTION
Pre-commit actions on github were using Conda environment without pip requirements.txt packages. Now, we install the pip packages before proceeding with pre-commit actions.